### PR TITLE
refactor(registry): Use config utility for model path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     # It ensures that the code is doing what you expects but it also makes it safe to modify existing code
     # since introducing new bugs has good chances to be detected if the tests are exahstive and well designed
     "pytest>=7.0.0",
+    "pytest-mock>=3.14.0",
 
     # Ruff is a popular library for formatting and linting code
     # Formatting is about purely stylistic issues, like indentation, line length, etc.

--- a/src/dsba/model_registry.py
+++ b/src/dsba/model_registry.py
@@ -1,109 +1,161 @@
-import joblib
 import json
 import logging
-import os
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+import joblib
 from sklearn.base import BaseEstimator
+
+# Import the config loading utility specifically for the path
+from dsba.config import get_models_root_path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
 class ClassifierMetadata:
     id: str
-    created_at: str
-    algorithm: str
-    hyperparameters: dict[str, Any]
     target_column: str
-    description: str
-    performance_metrics: dict[str, float]
+    algorithm: str = "Unknown"
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    hyperparameters: dict[str, Any] = field(default_factory=dict)
+    description: str = ""
+    performance_metrics: dict[str, float] = field(default_factory=dict)
 
 
 def save_model(model: BaseEstimator, metadata: ClassifierMetadata) -> None:
-    model_path = _get_model_path(metadata.id)
-    model_metadata_path = _get_model_metadata_path(metadata.id)
-    logging.info("Save model to path: " + str(model_path))
-    joblib.dump(model, model_path)
-    with open(model_metadata_path, "w") as f:
-        json.dump(asdict(metadata), f)
+    """Saves the model and its metadata to the configured registry path."""
+    # Get path via config utility and ensure it exists
+    models_dir = _get_models_dir_and_ensure_exists()
+    model_path = models_dir / f"{metadata.id}.pkl"
+    model_metadata_path = models_dir / f"{metadata.id}.json"
+
+    logger.info(f"Saving model '{metadata.id}' to {model_path}")
+    try:
+        joblib.dump(model, model_path)
+        logger.info(
+            f"Saving metadata for model '{metadata.id}' to {model_metadata_path}"
+        )
+        with open(model_metadata_path, "w") as f:
+            json.dump(asdict(metadata), f, indent=4, default=str)
+    except Exception as e:
+        logger.exception(f"Failed to save model or metadata for '{metadata.id}': {e}")
+        # Cleanup attempt
+        model_path.unlink(missing_ok=True)
+        model_metadata_path.unlink(missing_ok=True)
+        raise  # Re-raise
 
 
 def list_models_ids() -> list[str]:
-    models_dir = _get_models_dir()
-    model_files = _list_pickle_files(models_dir)
-    models_ids = [_remove_file_extension(model) for model in model_files]
-    return models_ids
+    """Lists the IDs of models available in the registry."""
+    models_dir = _get_models_dir_and_ensure_exists()  # Ensure dir exists before listing
+    try:
+        # List .pkl files and derive IDs
+        model_files = [
+            f for f in models_dir.iterdir() if f.is_file() and f.suffix == ".pkl"
+        ]
+        models_ids = [f.stem for f in model_files]
+        logger.info(f"Found models in registry: {models_ids}")
+        return models_ids
+    except OSError as e:
+        logger.exception(f"Error listing models in directory {models_dir}: {e}")
+        return []
 
 
-def load_model(model_id) -> BaseEstimator:
-    model_path = _get_model_path(model_id)
-    return _load_model_from_path(model_path)
+def load_model(model_id: str) -> BaseEstimator:
+    """Loads a model artifact from the registry."""
+    model_path = _get_model_path(model_id)  # Gets path using config
+    if not model_path.exists():
+        logger.error(
+            f"Model artifact file not found for ID '{model_id}' at {model_path}"
+        )
+        raise FileNotFoundError(f"Model artifact file not found for ID '{model_id}'")
+    logger.info(f"Loading model '{model_id}' from {model_path}")
+    try:
+        return joblib.load(model_path)
+    except Exception as e:
+        logger.exception(
+            f"Failed to load model artifact '{model_id}' from {model_path}: {e}"
+        )
+        raise  # Re-raise
 
 
-def load_model_metadata(model_id) -> ClassifierMetadata:
+def load_model_metadata(model_id: str) -> ClassifierMetadata:
+    """Loads model metadata from the registry."""
+    # Gets path using config
     metadata_path = _get_model_metadata_path(model_id)
-    with open(metadata_path, "r") as f:
-        metadata_as_dict = json.load(f)
-    metadata = ClassifierMetadata(**metadata_as_dict)
-    return metadata
-
-
-def _load_model_from_path(path: str | Path) -> BaseEstimator:
-    # A method starting with underscore is by convention a private method
-    # meaning it is not intended to be used outside of this file
-    # It is optional but facilitates the readability of the code
-    path = _get_absolute_path(path)
-    logging.info("Load model from path: " + str(path))
-    return joblib.load(path)
-
-
-def _get_model_metadata_path(model_id: str) -> Path:
-    models_dir = _get_models_dir()
-    metadata_path = os.path.join(models_dir, f"{model_id}.json")
-    return Path(metadata_path)
-
-
-def _get_model_path(model_id: str) -> Path:
-    models_dir = _get_models_dir()
-    model_path = os.path.join(models_dir, f"{model_id}.pkl")
-    return Path(model_path)
-
-
-def _get_models_dir() -> Path:
-    # We can't use a specific path here, it will be different on each machine.
-    # We could ask the client code where the models are every time they want to use this module.
-    # It would be fine. Instead, we use what is called an "environment variable".
-    # It is a way for the operating system to provide parameters to a program.
-    # Make sure to set this environment variable before calling this code.
-    DSBA_MODELS_ROOT_PATH = os.getenv("DSBA_MODELS_ROOT_PATH")
-    if DSBA_MODELS_ROOT_PATH is None:
+    if not metadata_path.exists():
+        logger.error(f"Metadata file not found for ID '{model_id}' at {metadata_path}")
+        raise FileNotFoundError(f"Metadata file not found for ID '{model_id}'")
+    logger.info(f"Loading metadata for model '{model_id}' from {metadata_path}")
+    try:
+        with open(metadata_path) as f:
+            metadata_as_dict = json.load(f)
+        metadata = ClassifierMetadata(**metadata_as_dict)
+        return metadata
+    except json.JSONDecodeError as e:
+        logger.exception(
+            f"Failed to decode JSON metadata for '{model_id}' from {metadata_path}: {e}"
+        )
+        raise ValueError(f"Invalid JSON metadata for model '{model_id}'") from e
+    except TypeError as e:
+        # This catches errors if JSON keys don't match dataclass fields
+        # (e.g., missing required fields or type mismatches).
+        logger.exception(
+            f"Mismatch between JSON structure and ClassifierMetadata "
+            f"for '{model_id}': {e}"
+        )
         raise ValueError(
-            "Environment variable DSBA_MODELS_ROOT_PATH is not set. "
-            "Please set it to the root path of the models."
+            f"Metadata structure mismatch for model '{model_id}'. "
+            f"Check required fields."
+        ) from e
+    except Exception as e:
+        logger.exception(
+            f"Failed to load metadata for '{model_id}' from {metadata_path}: {e}"
         )
-    models_dir = _get_absolute_path(DSBA_MODELS_ROOT_PATH)
-    if not Path(models_dir).exists():
-        logging.info(
-            f"Parent directory for models does not exist, creating it at {models_dir}"
+        raise  # Re-raise
+
+
+# --- Private Helper Functions ---
+
+
+# Renamed for clarity and responsibility
+def _get_models_dir_and_ensure_exists() -> Path:
+    """Gets the model directory path from config and ensures it exists."""
+    try:
+        models_dir = get_models_root_path()  # Use the config utility
+    except (FileNotFoundError, ValueError) as e:
+        logger.exception(f"Cannot determine models directory: {e}")
+        raise RuntimeError("Model registry path configuration error.") from e
+
+    # Ensure the directory exists
+    if not models_dir.exists():
+        logger.info(f"Models directory does not exist, creating it at {models_dir}")
+        try:
+            models_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.exception(f"Could not create models directory {models_dir}: {e}")
+            raise RuntimeError(f"Failed to create models directory {models_dir}") from e
+    elif not models_dir.is_dir():
+        logger.error(
+            f"Configured models path exists but is not a directory: {models_dir}"
         )
-        Path(models_dir).mkdir(parents=True)
+        raise NotADirectoryError(
+            f"Configured models path is not a directory: {models_dir}"
+        )
+
     return models_dir
 
 
-def _list_pickle_files(path: Path) -> list[str]:
-    """List all files in a directory that end with .pkl"""
-    return [f for f in os.listdir(path) if f.endswith(".pkl")]
+def _get_model_path(model_id: str) -> Path:
+    """Constructs the full path for a model artifact file using configured base path."""
+    models_dir = get_models_root_path()  # Get base path from config
+    return models_dir / f"{model_id}.pkl"
 
 
-def _get_absolute_path(path: str | Path) -> Path:
-    """
-    This is a purely technical function, it does not change the meaning of the path.
-    But for example, one of the issues it prevents:
-    if you just use "~/my/directory/and/file" some naive code may actually create a file with this name, starting with the caracter "~"
-    and not understand that this is supposed to refer to the user's home directory
-    """
-    return Path(path).expanduser().resolve(strict=False)
-
-
-def _remove_file_extension(file_name: str) -> str:
-    return os.path.splitext(file_name)[0]
+def _get_model_metadata_path(model_id: str) -> Path:
+    """Constructs the full path for a model metadata file using configured base path."""
+    models_dir = get_models_root_path()  # Get base path from config
+    return models_dir / f"{model_id}.json"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,154 @@
+import json
+from pathlib import Path
+
+# Import the function we need to mock
+import pytest
+from dsba.model_registry import (
+    ClassifierMetadata,
+    list_models_ids,
+    load_model,
+    load_model_metadata,
+    save_model,
+)
+from pytest_mock import MockerFixture
+from sklearn.linear_model import LogisticRegression
+
+MOCK_TARGET = "dsba.model_registry.get_models_root_path"
+
+# Test Suite for Model Registry Operations
+
+
+@pytest.fixture(scope="function")
+def mock_registry_path(tmp_path: Path, mocker: MockerFixture):
+    """
+    Mocks the get_models_root_path function used by model_registry
+    to return a temporary directory for isolated testing.
+    """
+    models_dir = tmp_path / "test_registry"
+    models_dir.mkdir()
+
+    mocker.patch(MOCK_TARGET, return_value=models_dir)
+
+    yield models_dir
+
+
+# Fixture for a sample model and metadata
+@pytest.fixture
+def sample_model_and_metadata():
+    model = LogisticRegression()
+    metadata = ClassifierMetadata(
+        id="test_model_01",
+        target_column="target",
+        algorithm="LogisticRegression",
+        description="A simple test model",
+        hyperparameters={"C": 1.0, "solver": "lbfgs"},
+        performance_metrics={"accuracy": 0.9},
+    )
+    return model, metadata
+
+
+def test_save_model_creates_files(mock_registry_path: Path, sample_model_and_metadata):
+    """Test that save_model creates .pkl and .json files in the mocked path."""
+    model, metadata = sample_model_and_metadata
+    registry_path = mock_registry_path
+
+    # save_model internally calls the mocked get_models_root_path()
+    save_model(model, metadata)
+
+    model_file = registry_path / f"{metadata.id}.pkl"
+    metadata_file = registry_path / f"{metadata.id}.json"
+
+    # Assertions should now work against the temp directory
+    assert model_file.exists()
+    assert model_file.is_file()
+    assert metadata_file.exists()
+    assert metadata_file.is_file()
+
+    # Verify metadata content
+    with open(metadata_file) as f:
+        saved_meta = json.load(f)
+        assert saved_meta["id"] == metadata.id
+        assert saved_meta["hyperparameters"] == metadata.hyperparameters
+
+
+def test_load_model_success(mock_registry_path: Path, sample_model_and_metadata):
+    """Test loading a previously saved model from the mocked path."""
+    model, metadata = sample_model_and_metadata
+    # Ensure save_model uses the mocked path by calling it within the test
+    save_model(model, metadata)
+
+    # load_model should now use the mocked path internally
+    loaded_model = load_model(metadata.id)
+    assert isinstance(loaded_model, LogisticRegression)
+    assert loaded_model.get_params()["C"] == 1.0
+
+
+def test_load_model_not_found(mock_registry_path: Path):
+    """Test loading a non-existent model raises FileNotFoundError from mocked path."""
+    # Mock ensures we look in the temp dir, where the model doesn't exist
+    with pytest.raises(FileNotFoundError):
+        load_model("non_existent_model")
+
+
+def test_load_metadata_success(mock_registry_path: Path, sample_model_and_metadata):
+    """Test loading previously saved metadata from the mocked path."""
+    model, metadata = sample_model_and_metadata
+    save_model(model, metadata)  # Save first using mocked path
+
+    # Load should use mocked path
+    loaded_metadata = load_model_metadata(metadata.id)
+    assert isinstance(loaded_metadata, ClassifierMetadata)
+    assert loaded_metadata.__dict__ == metadata.__dict__
+
+
+def test_load_metadata_not_found(mock_registry_path: Path):
+    """Test loading non-existent metadata raises FileNotFoundError from mocked path."""
+    with pytest.raises(FileNotFoundError):
+        load_model_metadata("non_existent_model")
+
+
+def test_load_metadata_missing_optional_fields(mock_registry_path: Path):
+    """Test loading metadata with missing optional fields from mocked path."""
+    registry_path = mock_registry_path
+    model_id = "minimal_model"
+    minimal_meta_dict = {
+        "id": model_id,
+        "target_column": "minimal_target",
+    }
+    metadata_file = registry_path / f"{model_id}.json"
+    with open(metadata_file, "w") as f:
+        json.dump(minimal_meta_dict, f)
+
+    # Create a dummy .pkl file in the mocked path
+    (registry_path / f"{model_id}.pkl").touch()
+
+    # Load should now correctly find and parse the file in the temp dir
+    loaded_metadata = load_model_metadata(model_id)
+    assert loaded_metadata.id == model_id
+    assert loaded_metadata.target_column == "minimal_target"
+    assert loaded_metadata.algorithm == "Unknown"
+    assert loaded_metadata.created_at is not None
+
+
+def test_list_models_ids(mock_registry_path: Path, sample_model_and_metadata):
+    """Test listing model IDs from the mocked path."""
+    registry_path = mock_registry_path  # Get mocked path for clarity
+
+    # list_models_ids should use the mocked path internally
+    assert list_models_ids() == []
+
+    # Save one model (uses mocked path)
+    model, metadata = sample_model_and_metadata
+    save_model(model, metadata)
+    assert list_models_ids() == [metadata.id]
+
+    # Save another model
+    model2 = LogisticRegression(C=0.5)
+    metadata2 = ClassifierMetadata(id="test_model_02", target_column="target2")
+    save_model(model2, metadata2)  # Uses mocked path
+
+    assert sorted(list_models_ids()) == sorted([metadata.id, metadata2.id])
+
+    # Check that non-model files in the temp dir are ignored
+    (registry_path / "not_a_model.txt").touch()
+    assert sorted(list_models_ids()) == sorted([metadata.id, metadata2.id])


### PR DESCRIPTION
- Update model_registry.py to get the registry path via dsba.config.get_models_root_path().
- Add comprehensive pytest tests for model registry operations (save, load, list) in test_model_registry.py, using mocking for path isolation.